### PR TITLE
#44 make it so the foreground is 100% opaque

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -23,10 +23,6 @@ void MainWindow::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
 
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    painter.fillRect(0, 0, config.getScreenGeometry().width(), config.getScreenGeometry().height(),
-                     QColor(QRgba64::fromRgba(0, 0, 0, 200)));
-
-    painter.setCompositionMode(QPainter::CompositionMode_SourceAtop);
     if (focused) {
         painter.drawPixmap(0, 0, screenBuffer);
     } else {
@@ -339,6 +335,7 @@ MainWindow::MainWindow() : QWidget() {
 
     setAttribute(Qt::WA_NoSystemBackground, true);
     setAttribute(Qt::WA_TranslucentBackground, true);
+    setAutoFillBackground(false);
 
     auto config = ConfigManager::getOrLoadConfig();
     auto geo = config.getScreenGeometry();

--- a/src/gui/drawer/ImageDrawer.cpp
+++ b/src/gui/drawer/ImageDrawer.cpp
@@ -173,28 +173,28 @@ void ImageDrawer::clearSelectedShapeIndicator(ShapeProperties shapeProperties, S
             pos.y() - selectedShapeLineWidth,
             shapeProperties.dimensions.x + (2 * selectedShapeLineWidth),
             selectedShapeLineWidth * 2,
-            Qt::transparent);
+            getBackgroundColor());
 
     painter.fillRect(
             pos.x() - selectedShapeLineWidth,
             pos.y() - selectedShapeLineWidth + shapeProperties.dimensions.y,
             shapeProperties.dimensions.x + (2 * selectedShapeLineWidth),
             selectedShapeLineWidth * 2,
-            Qt::transparent);
+            getBackgroundColor());
 
     painter.fillRect(
             pos.x() - selectedShapeLineWidth,
             pos.y() - selectedShapeLineWidth,
             (2 * selectedShapeLineWidth),
             shapeProperties.dimensions.y + selectedShapeLineWidth * 2,
-            Qt::transparent);
+            getBackgroundColor());
 
     painter.fillRect(
             pos.x() - selectedShapeLineWidth + shapeProperties.dimensions.x,
             pos.y() - selectedShapeLineWidth,
             (2 * selectedShapeLineWidth),
             shapeProperties.dimensions.y + selectedShapeLineWidth * 2,
-            Qt::transparent);
+            getBackgroundColor());
 
     painter.end();
 }
@@ -210,7 +210,7 @@ void ImageDrawer::clearShape(ShapeProperties shapeProperties, Shape shape) {
             shape.position.y() - 2,
             shapeProperties.dimensions.x + 4,
             shapeProperties.dimensions.y + 4,
-            Qt::transparent);
+            getBackgroundColor());
 
     painter.end();
 }

--- a/src/gui/drawer/ShapeDrawer.h
+++ b/src/gui/drawer/ShapeDrawer.h
@@ -29,19 +29,11 @@ protected:
     virtual void clearShape(ShapeProperties shapeProperties, Shape shape) = 0;
 
     void clearPixmap() {
-        QPainter painter;
+        pixmap.fill(getBackgroundColor());
+    }
 
-        painter.begin(&pixmap);
-        painter.setCompositionMode(QPainter::CompositionMode_Source);
-
-        painter.fillRect(
-                0,
-                0,
-                pixmap.width(),
-                pixmap.height(),
-                Qt::transparent);
-
-        painter.end();
+    QColor getBackgroundColor() {
+        return QColor(QRgba64::fromRgba(0, 0, 0, 200));
     }
 
 public:


### PR DESCRIPTION
1. use `CompositionMode_SourceOver` instead of `CompositionMode_SourceAtop` to draw pixmap on screen
2. draw background in pixmap when clearing using pixmaps `fill` instead of a painter